### PR TITLE
special case pre-release versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.2.0-dev.2
+
+- Added a (default on) option to not publish pre-release packages;
+  auto-publishing will only happen for stable (`'1.2.3'`) or build releases
+  (`'1.2.3+foo'`).
+
 ## 0.2.0-dev.1
 
 - Adjusted how github labels are passing into the script.

--- a/lib/firehose.dart
+++ b/lib/firehose.dart
@@ -62,11 +62,6 @@ class Firehose {
     print('');
     print('Found ${changedPackages.length} changed package(s).');
 
-    if (!env.containsKey(_pubEnvVar)) {
-      _failure('$_pubEnvVar env variable not found; the action will not be '
-          'able publish.');
-    }
-
     for (var package in changedPackages) {
       print('');
       var actionDescription = dryRun ? 'Validating' : 'Publishing';

--- a/lib/firehose.dart
+++ b/lib/firehose.dart
@@ -13,6 +13,9 @@ import 'src/utils.dart';
 class Firehose {
   final Directory directory;
 
+  /// Whether to auto-publish pre-release pubspec versions.
+  final bool publishPreReleaseVersions = false;
+
   Firehose(this.directory);
 
   void verify() async {
@@ -113,6 +116,10 @@ class Firehose {
           _failure("pubspec version ($pubspecVersion) and "
               "changelog ($changelogVersion)don't agree.");
         }
+        if (package.pubspec.isPreRelease && !publishPreReleaseVersions) {
+          print('Note - pubspec version is a pre-release version '
+              '($pubspecVersion); package will not be published.');
+        }
         if (issues == 0) {
           print('No issues found.');
         }
@@ -129,6 +136,9 @@ class Firehose {
       if (!dryRun) {
         if (!packageChangesFiles.contains('pubspec.yaml')) {
           print('pubspec.yaml not changed; not attempting to publish.');
+        } else if (package.pubspec.isPreRelease && !publishPreReleaseVersions) {
+          print('pubspec version is a pre-release version ($pubspecVersion); '
+              'package will not be published.');
         } else if (!env.containsKey('PUB_CREDENTIALS')) {
           _failure(
               'PUB_CREDENTIALS env variable not found; unable to publish.');

--- a/lib/src/pubspec.dart
+++ b/lib/src/pubspec.dart
@@ -17,6 +17,10 @@ class Pubspec {
   /// Return the package name.
   String get name => _yaml['name'];
 
+  /// Returns whether the pubspec semver version is a pre-release version
+  /// (`'1.2.3-foo'`).
+  bool get isPreRelease => semverVersion?.isPreRelease ?? false;
+
   /// Return the `'auto_publish'`, if any.
   Object? get autoPublishValue => _yaml['auto_publish'];
 

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -37,7 +37,7 @@ class ExecResults {
 /// Execute the given CLI command asynchronously, streaming stdout and stderr to
 /// the console.
 ///
-/// This will also echo the command being to stdout, and indent the processes
+/// This will also echo the command being run to stdout and indent the processes
 /// output slightly.
 Future<int> stream(
   String command, {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: firehose
 description: A tool to auto-publish pub packages from GitHub actions.
-version: 0.2.0-dev.1
+version: 0.2.0-dev.2
 repository: https://github.com/devoncarew/firehose
 
 # Property to allow auto-publishing from the default branch.


### PR DESCRIPTION
- Added a (default on) option to not publish pre-release packages; auto-publishing will only happen for stable (`'1.2.3'`) or build releases (`'1.2.3+foo'`).
